### PR TITLE
Clear path output each benchmark.

### DIFF
--- a/benchmark/64x64-benchmark.js
+++ b/benchmark/64x64-benchmark.js
@@ -30,6 +30,7 @@ var planner = createPlanner(maze)
 var path = []
 bench(`l1-path-finder [11, 11] to [63, 63] with very few obstacles ${numTimesToExecute} times`, function (b) {
   for (var i = 0; i < numTimesToExecute; i++) {
+    path.length = 0
     planner.search(11, 11, 63, 63, path)
   }
 


### PR DESCRIPTION
l1-path-finder does not resize the output, it just calls the push interface.  This fixes a memory leak by reseting the array length before each call to search.